### PR TITLE
Fix NameError for a more helpful error message

### DIFF
--- a/lib/image_intensities.rb
+++ b/lib/image_intensities.rb
@@ -4,7 +4,8 @@ require 'magic'
 
 module ImageIntensities
   def self.file(path)
-    case magic.file(path)
+    mime = magic.file(path)
+    case mime
     when 'image/png'
       ins = Native.png_intensities(path)
       raise 'Processing error' if ins[:error] != 0


### PR DESCRIPTION
This seems to have been the originally intended behavior.